### PR TITLE
Update requirement.txt

### DIFF
--- a/requirement.txt
+++ b/requirement.txt
@@ -13,5 +13,5 @@ gevent-websocket
 flask 
 editdistance 
 scikit-image 
-imgaug
+imgaug==0.2.8
 


### PR DESCRIPTION
Directly install packages using requirement.txt will meet the problem "AttributeError: module 'imgaug.augmenters' has no attribute 'Resize'",  so specify imgaug version to 0.2.8 at least.