### PR TITLE
calculate the box original width and height

### DIFF
--- a/structure/representers/seg_detector_representer.py
+++ b/structure/representers/seg_detector_representer.py
@@ -129,7 +129,7 @@ class SegDetectorRepresenter(Configurable):
         contours, _ = cv2.findContours(
             (bitmap * 255).astype(np.uint8),
             cv2.RETR_LIST, cv2.CHAIN_APPROX_SIMPLE)
-        num_contours = min(len(contours), self.max_candidates)
+        num_contours = len(contours)
         boxes = np.zeros((num_contours, 4, 2), dtype=np.int16)
         scores = np.zeros((num_contours,), dtype=np.float32)
 
@@ -143,7 +143,7 @@ class SegDetectorRepresenter(Configurable):
             if self.box_thresh > score:
                 continue
 
-            box = self.unclip(points,is_rect=True).reshape(-1, 1, 2)
+            box = self.unclip(points, is_rect=True).reshape(-1, 1, 2)
             box, sside = self.get_mini_boxes(box)
             if sside < self.min_size + 2:
                 continue

--- a/structure/representers/seg_detector_representer.py
+++ b/structure/representers/seg_detector_representer.py
@@ -129,7 +129,7 @@ class SegDetectorRepresenter(Configurable):
         contours, _ = cv2.findContours(
             (bitmap * 255).astype(np.uint8),
             cv2.RETR_LIST, cv2.CHAIN_APPROX_SIMPLE)
-        num_contours = len(contours)
+        num_contours = min(len(contours), self.max_candidates)
         boxes = np.zeros((num_contours, 4, 2), dtype=np.int16)
         scores = np.zeros((num_contours,), dtype=np.float32)
 
@@ -143,7 +143,7 @@ class SegDetectorRepresenter(Configurable):
             if self.box_thresh > score:
                 continue
 
-            box = self.unclip(points, is_rect=True).reshape(-1, 1, 2)
+            box = self.unclip(points,is_rect=True).reshape(-1, 1, 2)
             box, sside = self.get_mini_boxes(box)
             if sside < self.min_size + 2:
                 continue

--- a/structure/representers/seg_detector_representer.py
+++ b/structure/representers/seg_detector_representer.py
@@ -168,7 +168,7 @@ class SegDetectorRepresenter(Configurable):
             max_y = box[:, 1].max()
             h = max_y - min_y  # mini rect h
             w = max_x - min_x  # mini rect w
-            c = 1 - np.sqrt(0.4, 2)  # shrink_ratio 0.4
+            c = 1 - np.power(0.4, 2)  # shrink_ratio 0.4
             # calculate the original width and height according to the new width and height and shrink_ratio
             dt = ((2 * c - 2) * (h + w)) ** 2 - 4 * (4 * c - 8) * c * h * w
             distance = (-(2 * c - 2) * (h + w) - np.sqrt(dt)) / (2 * (4 * c - 8))


### PR DESCRIPTION
在浏览issue的时候看到一个有意思的讨论 #145 
很显然，适当的调整后处理的一些参数会带来更好的效果。
但是大家都没有讨论过unclip_ratio 这个参数，在原始的代码中，使用的是默认的参数1.5
但是对于不同的数据集，不同的宽高比，这个参数带来的误差还是比较大的，起码在我的数据集中是这样的。
既然新矩形的宽高是通过旧矩形通过固定过程裁剪出来的，我们就可以尝试计算二次方程来通过新的宽高求解原始宽高。
我尝试了一下，效果很不错。在我的数据集上，这种自适应的宽高，将F1从88.75%提高到了90.39%
限于时间和算力，我没有在其他数据集上进行评测，但是我觉得会有不错的效果。